### PR TITLE
Add cached votes count to telemetry message

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -678,7 +678,8 @@ bool nano::active_transactions::add (std::shared_ptr<nano::block> block_a, bool 
 			roots.get<tag_root> ().emplace (nano::conflict_info{ root, difficulty, difficulty, election });
 			blocks.insert (std::make_pair (hash, election));
 			adjust_difficulty (hash);
-			election->insert_inactive_votes_cache ();
+			auto inserted_votes (election->insert_inactive_votes_cache ());
+			cached_votes_cb.push_back (inserted_votes);
 		}
 	}
 	return error;

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -156,6 +156,7 @@ public:
 	void add_dropped_elections_cache (nano::qualified_root const &);
 	std::chrono::steady_clock::time_point find_dropped_elections_cache (nano::qualified_root const &);
 	size_t dropped_elections_cache_size ();
+	boost::circular_buffer<size_t> cached_votes_cb{ 1000 };
 
 private:
 	// Call action with confirmed block, may be different than what we started with

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -1147,6 +1147,7 @@ nano::telemetry_data nano::telemetry_data::consolidate (std::vector<nano::teleme
 	nano::uint128_t unchecked_sum{ 0 };
 	nano::uint128_t uptime_sum{ 0 };
 	nano::uint128_t bandwidth_sum{ 0 };
+	nano::uint128_t average_cached_votes_sum{ 0 };
 
 	std::unordered_map<uint8_t, int> protocol_versions;
 	std::unordered_map<uint8_t, int> vendor_versions;
@@ -1164,6 +1165,7 @@ nano::telemetry_data nano::telemetry_data::consolidate (std::vector<nano::teleme
 		protocol_sum += telemetry_data.protocol_version_number;
 		++protocol_versions[telemetry_data.protocol_version_number];
 		peer_sum += telemetry_data.peer_count;
+		average_cached_votes_sum += telemetry_data.average_cached_votes;
 
 		// 0 has a special meaning (unlimited), don't include it in the average as it will be heavily skewed
 		if (telemetry_data.bandwidth_cap != 0)
@@ -1183,6 +1185,7 @@ nano::telemetry_data nano::telemetry_data::consolidate (std::vector<nano::teleme
 	consolidated_data.peer_count = boost::numeric_cast<decltype (peer_count)> (peer_sum / size);
 	consolidated_data.uptime = boost::numeric_cast<decltype (uptime)> (uptime_sum / size);
 	consolidated_data.unchecked_count = boost::numeric_cast<decltype (unchecked_count)> (unchecked_sum / size);
+	consolidated_data.average_cached_votes = boost::numeric_cast<decltype (average_cached_votes)> (average_cached_votes_sum / size);
 
 	auto set_mode_or_average = [](auto const & collection, auto & var, auto const & sum, size_t size) {
 		auto max = std::max_element (collection.begin (), collection.end (), [](auto const & lhs, auto const & rhs) {

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -337,6 +337,7 @@ public:
 	uint64_t cemented_count{ 0 };
 	uint64_t unchecked_count{ 0 };
 	uint64_t account_count{ 0 };
+	uint64_t average_cached_votes{ 0 };
 	uint64_t bandwidth_cap{ 0 };
 	uint64_t uptime{ 0 };
 	uint32_t peer_count{ 0 };

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -306,7 +306,7 @@ void nano::election::clear_blocks ()
 	}
 }
 
-void nano::election::insert_inactive_votes_cache ()
+size_t nano::election::insert_inactive_votes_cache ()
 {
 	auto winner_hash (status.winner->hash ());
 	auto cache (node.active.find_inactive_votes_cache (winner_hash));
@@ -328,4 +328,5 @@ void nano::election::insert_inactive_votes_cache ()
 		}
 		confirm_if_quorum ();
 	}
+	return cache.voters.size ();
 }

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -50,7 +50,7 @@ public:
 	void update_dependent ();
 	void clear_dependent ();
 	void clear_blocks ();
-	void insert_inactive_votes_cache ();
+	size_t insert_inactive_votes_cache ();
 	void stop ();
 	nano::node & node;
 	std::unordered_map<nano::account, nano::vote_info> last_votes;

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -599,6 +599,7 @@ public:
 		nano::telemetry_data telemetry_data;
 		telemetry_data.block_count = node.ledger.block_count_cache;
 		telemetry_data.cemented_count = node.ledger.cemented_count;
+		telemetry_data.average_cached_votes = std::accumulate (node.active.cached_votes_cb.begin (), node.active.cached_votes_cb.end (), 0) / node.active.cached_votes_cb.size ();
 		telemetry_data.bandwidth_cap = node.config.bandwidth_limit;
 		telemetry_data.protocol_version_number = node.network_params.protocol.protocol_version;
 		telemetry_data.vendor_version = nano::get_major_node_version ();


### PR DESCRIPTION
No tests changed yet, but this would be the idea.